### PR TITLE
Fix bugs and improve Table performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
+    prism (1.9.0)
     psych (5.2.3)
       date
       stringio

--- a/lib/taql/cli.rb
+++ b/lib/taql/cli.rb
@@ -5,6 +5,7 @@ module Taql
     attr_reader :options, :query
 
     def initialize(argv)
+      @argv = argv
       @options = {markdown: false}
       @query = parse!
     end
@@ -24,7 +25,7 @@ module Taql
     def parse!
       OptionParser.new do |parser|
         parser.on("-m", "--markdown", TrueClass, "Output table in Markdown")
-      end.parse!(into: options)
+      end.parse!(@argv, into: options)
     end
 
     def silence

--- a/lib/taql/cli.rb
+++ b/lib/taql/cli.rb
@@ -8,6 +8,7 @@ module Taql
       @argv = argv
       @options = {markdown: false}
       @query = parse!
+      raise ArgumentError, "Usage: taql [--markdown] QUERY" if @query.empty?
     end
 
     def run

--- a/lib/taql/railtie.rb
+++ b/lib/taql/railtie.rb
@@ -11,8 +11,11 @@ module Taql
     end
 
     def self.connection
-      pool = ActiveRecord::Base.connection_pool
       pool.respond_to?(:lease_connection) ? pool.lease_connection : pool.connection
+    end
+
+    def self.pool
+      ActiveRecord::Base.connection_pool
     end
   end
 end

--- a/lib/taql/railtie.rb
+++ b/lib/taql/railtie.rb
@@ -6,8 +6,13 @@ module Taql
 
     initializer "taql.initialize" do
       ActiveSupport.on_load(:active_record) do
-        Taql.instance_variable_set(:@default_connection, -> { ActiveRecord::Base.connection_pool.connection })
+        Taql.instance_variable_set(:@default_connection, method(:connection))
       end
+    end
+
+    def self.connection
+      pool = ActiveRecord::Base.connection_pool
+      pool.respond_to?(:lease_connection) ? pool.lease_connection : pool.connection
     end
   end
 end

--- a/lib/taql/table.rb
+++ b/lib/taql/table.rb
@@ -17,13 +17,13 @@ module Taql
     end
 
     def columns
-      headers.map do |header|
+      @columns ||= headers.map do |header|
         [header, *entries.map { |entry| entry[header] }]
       end
     end
 
     def headers
-      entries.map(&:keys).uniq.flatten
+      @headers ||= entries.flat_map(&:keys).uniq
     end
 
     def print
@@ -43,7 +43,7 @@ module Taql
     end
 
     def column_widths
-      columns.map { |column| column.map(&:length).max }
+      @column_widths ||= columns.map { |column| column.map(&:length).max }
     end
 
     def edge

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -2,18 +2,14 @@ require "test_helper"
 
 class TestCli < Minitest::Test
   def test_that_it_parses_queries
-    ARGV.replace(["SELECT * FROM users"])
-
-    cli = Taql::Cli.new(ARGV)
+    cli = Taql::Cli.new(["SELECT * FROM users"])
 
     assert_equal "SELECT * FROM users", *cli.query
     assert_equal false, cli.options[:markdown]
   end
 
   def test_that_it_parses_options
-    ARGV.replace(["--markdown", "SELECT * FROM users"])
-
-    cli = Taql::Cli.new(ARGV)
+    cli = Taql::Cli.new(["--markdown", "SELECT * FROM users"])
 
     assert_equal "SELECT * FROM users", *cli.query
     assert_equal true, cli.options[:markdown]

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -14,4 +14,8 @@ class TestCli < Minitest::Test
     assert_equal "SELECT * FROM users", *cli.query
     assert_equal true, cli.options[:markdown]
   end
+
+  def test_that_it_raises_without_query
+    assert_raises(ArgumentError) { Taql::Cli.new([]) }
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,4 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "taql"
 require "minitest/autorun"
+require "minitest/mock"

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -69,4 +69,12 @@ class TestTable < Minitest::Test
     assert_output("\n") { puts empty_table.print }
   end
 
+  def test_headers_with_heterogeneous_entries
+    table = Taql::Table.new([
+      {"name" => "Alice", "age" => 30},
+      {"name" => "Bob", "email" => "bob@example.com"}
+    ])
+
+    assert_equal ["name", "age", "email"], table.headers
+  end
 end

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -68,4 +68,5 @@ class TestTable < Minitest::Test
 
     assert_output("\n") { puts empty_table.print }
   end
+
 end


### PR DESCRIPTION
## Summary
- Fix CLI to use passed `argv` instead of relying on global `ARGV`
- Memoize `headers`, `columns`, and `column_widths` in Table to avoid recomputation per row
- Fix `headers` deduplication for heterogeneous entries
- Raise error when CLI is invoked without a query
- Use `lease_connection` for Rails 7.2+ compatibility
- Add `minitest/mock` require for Ruby 4.0 compatibility